### PR TITLE
Fix chat horizontal overflow on mobile

### DIFF
--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -36,8 +36,8 @@ export function ChatInput({ onSendText, onSendImage, disabled }: ChatInputProps)
   };
 
   return (
-    <div className="border-t bg-card p-3 safe-area-inset-bottom">
-      <form onSubmit={handleSubmit} className="flex items-center gap-2">
+    <div className="border-t bg-card p-3 safe-area-inset-bottom overflow-hidden">
+      <form onSubmit={handleSubmit} className="flex items-center gap-2 min-w-0">
         {/* Hidden file inputs */}
         <input
           ref={cameraInputRef}
@@ -83,7 +83,7 @@ export function ChatInput({ onSendText, onSendImage, disabled }: ChatInputProps)
         </div>
 
         {/* Text input */}
-        <div className="flex-1 relative">
+        <div className="flex-1 relative min-w-0">
           <input
             type="text"
             value={text}

--- a/src/components/chat/MarkdownText.tsx
+++ b/src/components/chat/MarkdownText.tsx
@@ -12,7 +12,7 @@ export function MarkdownText({ children, className }: MarkdownTextProps) {
   }, [children]);
 
   return (
-    <span className={className} dangerouslySetInnerHTML={{ __html: rendered }} />
+    <span className={`break-words ${className || ''}`} dangerouslySetInnerHTML={{ __html: rendered }} />
   );
 }
 

--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -43,7 +43,7 @@ export function MessageBubble({
     >
       <div
         className={cn(
-          'max-w-[85%]',
+          'max-w-[85%] min-w-0',
           isUser
             ? message.imageData
               ? 'rounded-2xl rounded-br-md overflow-hidden bg-primary text-primary-foreground'
@@ -64,7 +64,7 @@ export function MessageBubble({
               />
             )}
             {message.content && (
-              <div className={cn('text-sm', message.imageData && isUser && 'px-4 py-2')}>
+              <div className={cn('text-sm min-w-0', message.imageData && isUser && 'px-4 py-2')}>
                 <MarkdownText>{message.content}</MarkdownText>
               </div>
             )}

--- a/src/pages/UnifiedChat.tsx
+++ b/src/pages/UnifiedChat.tsx
@@ -676,7 +676,7 @@ export function UnifiedChat() {
   }
 
   return (
-    <div className="flex flex-col flex-1 min-h-0">
+    <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
       {/* Compact progress bar */}
       <div className="px-4 py-2 border-b bg-muted/30">
         <div className="flex items-center justify-between text-sm">
@@ -697,7 +697,7 @@ export function UnifiedChat() {
       </div>
 
       {/* Messages */}
-      <div className="flex-1 overflow-y-auto p-4 pb-2 min-h-0 scroll-smooth overscroll-contain">
+      <div className="flex-1 overflow-y-auto overflow-x-hidden p-4 pb-2 min-h-0 scroll-smooth overscroll-contain">
         {messages.map((message, index) => {
           // Show LoggedFoodCard for messages with confirmed food entries
           // Check both message.foodEntry (new) and lookup by syncId (old messages)


### PR DESCRIPTION
## Summary
- Fix horizontal overflow in chat view that caused layout issues on mobile
- Add `overflow-hidden` to main chat container and input area
- Add `min-w-0` to flex containers for proper content sizing
- Add `break-words` to markdown text to handle long content

## Test plan
- [x] Tested on localhost with mobile viewport emulation
- [ ] Test on actual mobile device after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)