### PR TITLE
v0.9.36: Fix mobile overflow with position fixed body

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "protee",
-  "version": "0.9.35",
+  "version": "0.9.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "protee",
-      "version": "0.9.35",
+      "version": "0.9.36",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.71.2",
         "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "protee",
   "private": true,
-  "version": "0.9.35",
+  "version": "0.9.36",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -21,7 +21,7 @@ export function Layout() {
   const disablePullToRefresh = location.pathname === '/coach' || location.pathname === '/chat' || location.pathname === '/advisor';
 
   return (
-    <div className="flex flex-col h-screen bg-background overflow-hidden">
+    <div className="flex flex-col h-full bg-background overflow-hidden">
       <Header />
       {disablePullToRefresh ? (
         <div className="flex-1 pb-24 overflow-hidden flex flex-col min-h-0">

--- a/src/index.css
+++ b/src/index.css
@@ -55,18 +55,32 @@
     -moz-osx-font-smoothing: grayscale;
   }
 
-  html, body, #root {
+  html {
+    height: 100%;
+    height: -webkit-fill-available;
+    overflow: hidden;
+  }
+
+  body {
+    height: 100%;
+    min-height: -webkit-fill-available;
+    overflow: hidden;
+    position: fixed;
+    width: 100%;
+    left: 0;
+    top: 0;
+  }
+
+  #root {
     height: 100%;
     overflow: hidden;
     width: 100%;
-    max-width: 100vw;
   }
 
-  /* Prevent pull-to-refresh and horizontal scroll on mobile */
-  body {
-    overscroll-behavior-y: contain;
-    overscroll-behavior-x: none;
-    -webkit-overflow-scrolling: touch;
+  /* Global text overflow handling */
+  * {
+    word-wrap: break-word;
+    overflow-wrap: break-word;
   }
 
   /* Safe area insets for notched devices */


### PR DESCRIPTION
## Summary
Fix horizontal overflow on iOS (Arc/Safari) with aggressive viewport locking.

## Changes
- `index.css`: Use `position: fixed` on body, add `-webkit-fill-available`, global word-wrap
- `Layout.tsx`: Change from `h-screen` to `h-full`

## Test plan
- [x] Tested on mobile viewport emulation
- [ ] Test on iPhone with Arc browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)