### PR TITLE
v0.9.37: Prevent iOS auto-zoom on input focus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "protee",
-  "version": "0.9.36",
+  "version": "0.9.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "protee",
-      "version": "0.9.36",
+      "version": "0.9.37",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.71.2",
         "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "protee",
   "private": true,
-  "version": "0.9.36",
+  "version": "0.9.37",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/index.css
+++ b/src/index.css
@@ -83,6 +83,11 @@
     overflow-wrap: break-word;
   }
 
+  /* Prevent iOS zoom on input focus - must be 16px or larger */
+  input, textarea, select {
+    font-size: 16px !important;
+  }
+
   /* Safe area insets for notched devices */
   .safe-area-inset-bottom {
     padding-bottom: env(safe-area-inset-bottom);


### PR DESCRIPTION
## Summary
Fix iOS auto-zoom when tapping input fields.

iOS automatically zooms in on form fields with font-size < 16px. This adds a CSS rule to force all inputs, textareas, and selects to 16px minimum.

## Changes
- `index.css`: Add `font-size: 16px !important` to input, textarea, select

🤖 Generated with [Claude Code](https://claude.com/claude-code)