### PR TITLE
v0.9.38: Show quick log suggestions on input focus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "protee",
-  "version": "0.9.37",
+  "version": "0.9.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "protee",
-      "version": "0.9.37",
+      "version": "0.9.38",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.71.2",
         "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "protee",
   "private": true,
-  "version": "0.9.37",
+  "version": "0.9.38",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/chat/ChatInput.tsx
+++ b/src/components/chat/ChatInput.tsx
@@ -6,15 +6,35 @@ import { compressImage } from '@/lib/utils';
 interface ChatInputProps {
   onSend: (text: string, images: string[]) => void;
   disabled?: boolean;
+  onFocusChange?: (focused: boolean, hasText: boolean) => void;
 }
 
 const MAX_IMAGES = 4;
 
-export function ChatInput({ onSend, disabled }: ChatInputProps) {
+export function ChatInput({ onSend, disabled, onFocusChange }: ChatInputProps) {
   const [text, setText] = useState('');
   const [pendingImages, setPendingImages] = useState<string[]>([]);
+  const [isFocused, setIsFocused] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const cameraInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFocus = () => {
+    setIsFocused(true);
+    onFocusChange?.(true, text.trim().length > 0);
+  };
+
+  const handleBlur = () => {
+    setIsFocused(false);
+    onFocusChange?.(false, text.trim().length > 0);
+  };
+
+  const handleTextChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newText = e.target.value;
+    setText(newText);
+    if (isFocused) {
+      onFocusChange?.(true, newText.trim().length > 0);
+    }
+  };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -120,7 +140,9 @@ export function ChatInput({ onSend, disabled }: ChatInputProps) {
           <input
             type="text"
             value={text}
-            onChange={(e) => setText(e.target.value)}
+            onChange={handleTextChange}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
             placeholder={pendingImages.length > 0 ? "Add details (optional)..." : "Describe your meal..."}
             disabled={disabled}
             className="w-full h-10 px-4 rounded-full bg-muted/50 border-0 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/20 disabled:opacity-50"

--- a/src/components/chat/QuickLogShortcuts.tsx
+++ b/src/components/chat/QuickLogShortcuts.tsx
@@ -30,7 +30,7 @@ export function QuickLogShortcuts({ onSelect, disabled }: QuickLogShortcutsProps
   }
 
   return (
-    <div className="px-4 pb-2">
+    <div className="px-4 pb-2 animate-in fade-in slide-in-from-bottom-2 duration-200">
       <div className="flex items-center gap-1.5 text-xs text-muted-foreground mb-2">
         <Clock className="h-3 w-3" />
         <span>Quick log</span>

--- a/src/pages/UnifiedChat.tsx
+++ b/src/pages/UnifiedChat.tsx
@@ -92,6 +92,9 @@ export function UnifiedChat() {
   // Edit dialog state
   const [editingEntry, setEditingEntry] = useState<FoodEntry | null>(null);
 
+  // Input focus state for showing quick log suggestions
+  const [showQuickLogSuggestions, setShowQuickLogSuggestions] = useState(false);
+
   // Load messages on mount
   useEffect(() => {
     loadMessages();
@@ -621,7 +624,16 @@ export function UnifiedChat() {
         },
       },
     });
+
+    // Hide suggestions after selecting
+    setShowQuickLogSuggestions(false);
   };
+
+  // Handle input focus change for quick log suggestions
+  const handleInputFocusChange = useCallback((focused: boolean, hasText: boolean) => {
+    // Show suggestions only when focused and input is empty
+    setShowQuickLogSuggestions(focused && !hasText);
+  }, []);
 
   // Handle edit click on logged food card
   const handleEditLoggedFood = (entry: FoodEntry) => {
@@ -781,8 +793,8 @@ export function UnifiedChat() {
         <div ref={messagesEndRef} />
       </div>
 
-      {/* Quick Log Shortcuts */}
-      {!pendingFood && !isProcessing && (
+      {/* Quick Log Shortcuts - shown when input is focused and empty */}
+      {!pendingFood && !isProcessing && showQuickLogSuggestions && (
         <QuickLogShortcuts
           onSelect={handleQuickLog}
           disabled={isProcessing}
@@ -793,6 +805,7 @@ export function UnifiedChat() {
       <ChatInput
         onSend={handleSend}
         disabled={isProcessing}
+        onFocusChange={handleInputFocusChange}
       />
 
       {/* Edit Dialog */}


### PR DESCRIPTION
## Summary
Quick log chips now only appear when the text input is focused and empty, similar to iOS autocomplete suggestions.

## Changes
- `ChatInput.tsx`: Add `onFocusChange` callback to track focus and text state
- `UnifiedChat.tsx`: Show QuickLogShortcuts only when focused with empty input
- `QuickLogShortcuts.tsx`: Add fade-in animation

## UX improvement
- Cleaner chat interface when not actively typing
- Suggestions appear naturally when user taps input
- Disappear when user starts typing

🤖 Generated with [Claude Code](https://claude.com/claude-code)