### PR TITLE
v0.9.40: Fix duplicate cards and remove toast

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "protee",
   "private": true,
-  "version": "0.9.39",
+  "version": "0.9.40",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -1,34 +1,22 @@
 import { AlertCircle } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { ChatMessage } from '@/types';
-import { FoodCard } from './FoodCard';
 import { QuickReplies } from './QuickReplies';
 import { TypingIndicator } from './TypingIndicator';
 import { MarkdownText } from './MarkdownText';
 
 interface MessageBubbleProps {
   message: ChatMessage;
-  onConfirm?: (entry: ChatMessage['foodEntry']) => void;
-  onEdit?: (entry: ChatMessage['foodEntry']) => void;
-  onDelete?: (entry: ChatMessage['foodEntry']) => void;
-  onCancel?: (entry: ChatMessage['foodEntry']) => void;
   onQuickReply?: (reply: string) => void;
-  showCalories?: boolean;
   isLatestMessage?: boolean;
 }
 
 export function MessageBubble({
   message,
-  onConfirm,
-  onEdit,
-  onDelete,
-  onCancel,
   onQuickReply,
-  showCalories,
   isLatestMessage,
 }: MessageBubbleProps) {
   const isUser = message.type === 'user';
-  const isConfirmed = !!message.foodEntrySyncId;
 
   // Get images array (support both legacy imageData and new images array)
   const messageImages = message.images || (message.imageData ? [message.imageData] : []);
@@ -96,19 +84,6 @@ export function MessageBubble({
                   <AlertCircle className="h-4 w-4 inline-block mr-1.5 -mt-0.5" />
                 )}
                 <MarkdownText>{message.content}</MarkdownText>
-              </div>
-            )}
-            {message.foodEntry && (
-              <div className={message.content ? 'mt-2' : ''}>
-                <FoodCard
-                  entry={message.foodEntry}
-                  onConfirm={() => onConfirm?.(message.foodEntry)}
-                  onEdit={() => onEdit?.(message.foodEntry)}
-                  onDelete={() => onDelete?.(message.foodEntry)}
-                  onCancel={() => onCancel?.(message.foodEntry)}
-                  showCalories={showCalories}
-                  isConfirmed={isConfirmed}
-                />
               </div>
             )}
             {showQuickReplies && onQuickReply && (


### PR DESCRIPTION
## Summary
- Fix duplicate food cards showing (big FoodCard + compact LoggedFoodCard)
- Remove confirmation toast that was covering the progress feedback

## Fixes
- **Duplicate cards**: Removed FoodCard rendering from MessageBubble since UnifiedChat now handles all food card rendering. Previously both components were rendering cards for confirmed entries.
- **Toast removed**: The toast was covering the +Xg progress animation. Progress bar animation is sufficient feedback.

## Test plan
- [ ] Log food → only compact LoggedFoodCard should appear below AI message (no big card)
- [ ] Confirm food → no toast appears
- [ ] Progress +Xg animation should be visible
- [ ] Delete via swipe should work correctly (no duplicate delete buttons)

🤖 Generated with [Claude Code](https://claude.com/claude-code)