### PR TITLE
v0.9.41: Fix nav position in standalone PWA mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "protee",
   "private": true,
-  "version": "0.9.40",
+  "version": "0.9.41",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect, useCallback } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
 import { Header } from './Header';
 import { MobileNav } from './MobileNav';
@@ -5,12 +6,28 @@ import { PullToRefresh } from '@/components/ui/PullToRefresh';
 import { FloatingAddButton } from './FloatingAddButton';
 import { useAuthStore } from '@/store/useAuthStore';
 import { useStore } from '@/store/useStore';
-import { useCallback } from 'react';
 
 export function Layout() {
   const location = useLocation();
   const { syncData, isSyncing, user } = useAuthStore();
   const { showFloatingAddButton } = useStore();
+
+  // Detect if running as standalone PWA (Arc browser adds its own toolbar)
+  const [isStandalone, setIsStandalone] = useState(false);
+
+  useEffect(() => {
+    const checkStandalone = () => {
+      const isStandaloneMode =
+        window.matchMedia('(display-mode: standalone)').matches ||
+        (window.navigator as unknown as { standalone?: boolean }).standalone === true;
+      setIsStandalone(isStandaloneMode);
+    };
+    checkStandalone();
+
+    const mediaQuery = window.matchMedia('(display-mode: standalone)');
+    mediaQuery.addEventListener('change', checkStandalone);
+    return () => mediaQuery.removeEventListener('change', checkStandalone);
+  }, []);
 
   const handleRefresh = useCallback(async () => {
     if (!user) return;
@@ -20,18 +37,21 @@ export function Layout() {
   // Disable pull-to-refresh on coach page (has its own scroll container)
   const disablePullToRefresh = location.pathname === '/coach' || location.pathname === '/chat' || location.pathname === '/advisor';
 
+  // Increase bottom padding in standalone mode to account for Arc's PWA toolbar
+  const bottomPadding = isStandalone ? 'pb-32' : 'pb-20';
+
   return (
     <div className="flex flex-col h-full bg-background overflow-hidden">
       <Header />
       {disablePullToRefresh ? (
-        <div className="flex-1 pb-20 overflow-hidden flex flex-col min-h-0">
+        <div className={`flex-1 ${bottomPadding} overflow-hidden flex flex-col min-h-0`}>
           <Outlet />
         </div>
       ) : (
         <PullToRefresh
           onRefresh={handleRefresh}
           disabled={isSyncing}
-          className="flex-1 pb-20"
+          className={`flex-1 ${bottomPadding}`}
         >
           <Outlet />
         </PullToRefresh>

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import { Home, MessageSquare, Calendar, Settings } from 'lucide-react';
 import { NavLink } from 'react-router-dom';
 import { cn } from '@/lib/utils';
@@ -10,8 +11,30 @@ const navItems = [
 ];
 
 export function MobileNav() {
+  // Detect if running as standalone PWA (Arc browser adds its own toolbar)
+  const [isStandalone, setIsStandalone] = useState(false);
+
+  useEffect(() => {
+    // Check for standalone mode (PWA installed)
+    const checkStandalone = () => {
+      const isStandaloneMode =
+        window.matchMedia('(display-mode: standalone)').matches ||
+        (window.navigator as unknown as { standalone?: boolean }).standalone === true;
+      setIsStandalone(isStandaloneMode);
+    };
+    checkStandalone();
+
+    // Listen for changes
+    const mediaQuery = window.matchMedia('(display-mode: standalone)');
+    mediaQuery.addEventListener('change', checkStandalone);
+    return () => mediaQuery.removeEventListener('change', checkStandalone);
+  }, []);
+
   return (
-    <nav className="fixed bottom-4 left-4 right-4 z-50 floating-nav safe-area-inset-bottom">
+    <nav className={cn(
+      "fixed left-4 right-4 z-50 floating-nav safe-area-inset-bottom",
+      isStandalone ? "bottom-14" : "bottom-4" // Extra space for Arc's PWA toolbar
+    )}>
       <div className="flex items-center justify-around h-14 px-2">
         {navItems.map(({ to, icon: Icon, label }) => (
           <NavLink


### PR DESCRIPTION
## Summary
Fix navigation bar position when app is installed as PWA on iOS with Arc browser.

## Problem
Arc browser on iOS adds its own navigation toolbar at the bottom when running as a standalone PWA. This was causing our floating nav to appear too close to the bottom, partially obscured.

## Solution
- Detect standalone mode using `display-mode: standalone` media query
- When in standalone mode:
  - Move nav up from `bottom-4` to `bottom-14`
  - Increase content bottom padding from `pb-20` to `pb-32`

## Test plan
- [ ] Test in Arc browser (should look normal)
- [ ] Test in Arc PWA mode (delete and reinstall app from home screen)
- [ ] Nav should no longer overlap with Arc's toolbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)