### PR TITLE
v0.9.42: Fix nav double-height in PWA standalone mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "protee",
   "private": true,
-  "version": "0.9.41",
+  "version": "0.9.42",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,4 +1,3 @@
-import { useState, useEffect, useCallback } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
 import { Header } from './Header';
 import { MobileNav } from './MobileNav';
@@ -6,28 +5,12 @@ import { PullToRefresh } from '@/components/ui/PullToRefresh';
 import { FloatingAddButton } from './FloatingAddButton';
 import { useAuthStore } from '@/store/useAuthStore';
 import { useStore } from '@/store/useStore';
+import { useCallback } from 'react';
 
 export function Layout() {
   const location = useLocation();
   const { syncData, isSyncing, user } = useAuthStore();
   const { showFloatingAddButton } = useStore();
-
-  // Detect if running as standalone PWA (Arc browser adds its own toolbar)
-  const [isStandalone, setIsStandalone] = useState(false);
-
-  useEffect(() => {
-    const checkStandalone = () => {
-      const isStandaloneMode =
-        window.matchMedia('(display-mode: standalone)').matches ||
-        (window.navigator as unknown as { standalone?: boolean }).standalone === true;
-      setIsStandalone(isStandaloneMode);
-    };
-    checkStandalone();
-
-    const mediaQuery = window.matchMedia('(display-mode: standalone)');
-    mediaQuery.addEventListener('change', checkStandalone);
-    return () => mediaQuery.removeEventListener('change', checkStandalone);
-  }, []);
 
   const handleRefresh = useCallback(async () => {
     if (!user) return;
@@ -37,21 +20,18 @@ export function Layout() {
   // Disable pull-to-refresh on coach page (has its own scroll container)
   const disablePullToRefresh = location.pathname === '/coach' || location.pathname === '/chat' || location.pathname === '/advisor';
 
-  // Increase bottom padding in standalone mode to account for Arc's PWA toolbar
-  const bottomPadding = isStandalone ? 'pb-32' : 'pb-20';
-
   return (
     <div className="flex flex-col h-full bg-background overflow-hidden">
       <Header />
       {disablePullToRefresh ? (
-        <div className={`flex-1 ${bottomPadding} overflow-hidden flex flex-col min-h-0`}>
+        <div className="flex-1 pb-20 overflow-hidden flex flex-col min-h-0">
           <Outlet />
         </div>
       ) : (
         <PullToRefresh
           onRefresh={handleRefresh}
           disabled={isSyncing}
-          className={`flex-1 ${bottomPadding}`}
+          className="flex-1 pb-20"
         >
           <Outlet />
         </PullToRefresh>

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -1,4 +1,3 @@
-import { useState, useEffect } from 'react';
 import { Home, MessageSquare, Calendar, Settings } from 'lucide-react';
 import { NavLink } from 'react-router-dom';
 import { cn } from '@/lib/utils';
@@ -11,30 +10,8 @@ const navItems = [
 ];
 
 export function MobileNav() {
-  // Detect if running as standalone PWA (Arc browser adds its own toolbar)
-  const [isStandalone, setIsStandalone] = useState(false);
-
-  useEffect(() => {
-    // Check for standalone mode (PWA installed)
-    const checkStandalone = () => {
-      const isStandaloneMode =
-        window.matchMedia('(display-mode: standalone)').matches ||
-        (window.navigator as unknown as { standalone?: boolean }).standalone === true;
-      setIsStandalone(isStandaloneMode);
-    };
-    checkStandalone();
-
-    // Listen for changes
-    const mediaQuery = window.matchMedia('(display-mode: standalone)');
-    mediaQuery.addEventListener('change', checkStandalone);
-    return () => mediaQuery.removeEventListener('change', checkStandalone);
-  }, []);
-
   return (
-    <nav className={cn(
-      "fixed left-4 right-4 z-50 floating-nav safe-area-inset-bottom",
-      isStandalone ? "bottom-14" : "bottom-4" // Extra space for Arc's PWA toolbar
-    )}>
+    <nav className="fixed bottom-4 left-4 right-4 z-50 floating-nav">
       <div className="flex items-center justify-around h-14 px-2">
         {navItems.map(({ to, icon: Icon, label }) => (
           <NavLink


### PR DESCRIPTION
## Summary
- Reverts v0.9.41 standalone detection that was causing the navigation bar to appear double height in PWA mode
- Removes unnecessary `safe-area-inset-bottom` class and conditional bottom offsets
- Returns nav to simple fixed positioning with `bottom-4`

## Test plan
- [ ] Open app in PWA standalone mode on iPhone
- [ ] Verify nav bar appears at correct single height (not double)
- [ ] Verify no extra white space below nav icons or below logged items list

🤖 Generated with [Claude Code](https://claude.com/claude-code)