### PR TITLE
v0.9.43: Improve History popovers with dismissible UI and day navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "protee",
   "private": true,
-  "version": "0.9.42",
+  "version": "0.9.43",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary
- Fix WeeklyChart popover: replaced recharts Tooltip with custom popover that closes on outside tap
- Add popover to CalendarView when tapping on any date  
- Both popovers include "View day" button to navigate to Dashboard showing that day's details
- Dashboard reads date from URL params (`/?date=YYYY-MM-DD`) for deep linking from History

## Test plan
- [ ] Tap on a bar in Week view - popover appears with day summary
- [ ] Tap outside popover - it dismisses
- [ ] Tap "View day" - navigates to Dashboard showing that day
- [ ] Tap on a date in Month view - popover appears
- [ ] Tap outside or "View day" - works correctly
- [ ] Swipe to change week/month - popover closes automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)