### PR TITLE
v0.9.44: Save daily goal on every food entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "protee",
   "private": true,
-  "version": "0.9.43",
+  "version": "0.9.44",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/pages/UnifiedChat.tsx
+++ b/src/pages/UnifiedChat.tsx
@@ -14,7 +14,7 @@ import { useProgressInsights } from '@/hooks/useProgressInsights';
 import { useAuthStore } from '@/store/useAuthStore';
 import { useStore } from '@/store/useStore';
 import { getNickname } from '@/lib/nicknames';
-import { addFoodEntry, deleteFoodEntryBySyncId, cleanupOldChatMessages, updateFoodEntry, getEntriesForDateRange } from '@/db';
+import { addFoodEntry, deleteFoodEntryBySyncId, cleanupOldChatMessages, updateFoodEntry, getEntriesForDateRange, setDailyGoal } from '@/db';
 import { triggerSync } from '@/store/useAuthStore';
 import { getToday, calculateMPSHits, calculateMPSAnalysis, calculateCategoryBreakdown, triggerHaptic } from '@/lib/utils';
 import { refineAnalysis } from '@/services/ai/client';
@@ -500,6 +500,10 @@ export function UnifiedChat() {
     };
 
     await addFoodEntry(foodEntry);
+
+    // Save the current goal for this day (updates on every entry to capture goal changes)
+    await setDailyGoal(entryDate, settings.defaultGoal, settings.calorieGoal);
+
     triggerHaptic('success');
 
     // Show progress feedback animation


### PR DESCRIPTION
## Summary
- Save the current protein/calorie goal for the day whenever food is logged
- Updates on every entry to capture goal changes mid-day
- Historical days now remember what goal was active when food was logged

## How it works
When confirming a food entry, the app now calls `setDailyGoal(date, proteinGoal, calorieGoal)` to save the current goal for that day. This uses the existing `dailyGoals` table that was already in the database but wasn't being populated.

## Test plan
- [ ] Log food with current goal (e.g., 150g)
- [ ] Change goal in settings (e.g., to 180g)
- [ ] Check history - previous days should still show 150g as their goal
- [ ] Log food on today - today's goal should now be 180g
- [ ] Change goal again to 200g
- [ ] Log more food on today - goal updates to 200g

🤖 Generated with [Claude Code](https://claude.com/claude-code)